### PR TITLE
Added exception to plurality rule for version resource in routes

### DIFF
--- a/fixtures/lint/version-pass.yaml
+++ b/fixtures/lint/version-pass.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: API Fixture
+  description: API fixture description
+  license:
+    name: Apache2
+  contact:
+    email: support@example.com
+servers:
+  - url: https://api.example.com/v1
+tags:
+  - name: Test
+    description: Test tag
+paths:
+  /v2/tests:
+    get:
+      summary: Test operation
+      description: Test operation description
+      operationId: test
+      tags:
+        - Test
+      responses:
+        "204":
+          description: Response description

--- a/isp-functions/noun-deps.js
+++ b/isp-functions/noun-deps.js
@@ -59,6 +59,10 @@ module.exports = targetValue => {
   for (const value of pieces.slice(0, -1)) {
     if (value.startsWith('{')) continue;
 
+    // our api version is in the url as a resource
+    // this does not need to be plural
+    if (value.match(/v[0-9]+/)) continue;
+
     // Ensure words are plural if later paths exist.
     const plural = inflection.pluralize(value);
     if (value !== plural) {


### PR DESCRIPTION
Before the linter would complain about `/v2/resource` that `v2` needs to be `v2s`.  This PR adds an exception to that rule for api versions.