### PR TITLE
Disable English rules from linter

### DIFF
--- a/fixtures/lint/english-fail.yaml
+++ b/fixtures/lint/english-fail.yaml
@@ -1,26 +1,27 @@
-openapi: '3.0.0'
-info:
-  version: 1.0.0
-  title: API Fixture
-  description: |
-    This is a description. Very good.
-  license:
-    name: Apache2
-  contact:
-    email: support@example.com
-servers:
-  - url: https://api.example.com/v1
-tags:
-  - name: Test
-    description: Test tag
-paths:
-  /tests:
-    get:
-      summary: Test operation
-      description: Test operation description
-      operationId: test
-      tags:
-        - Test
-      responses:
-        '204':
-          description: Response description
+# TODO: Uncomment when English rules are readded
+# openapi: '3.0.0'
+# info:
+#   version: 1.0.0
+#   title: API Fixture
+#   description: |
+#     This is a description. Very good.
+#   license:
+#     name: Apache2
+#   contact:
+#     email: support@example.com
+# servers:
+#   - url: https://api.example.com/v1
+# tags:
+#   - name: Test
+#     description: Test tag
+# paths:
+#   /tests:
+#     get:
+#       summary: Test operation
+#       description: Test operation description
+#       operationId: test
+#       tags:
+#         - Test
+#       responses:
+#         '204':
+#           description: Response description

--- a/isp-rules.yaml
+++ b/isp-rules.yaml
@@ -1,19 +1,20 @@
+# TODO: Readd English rules when ChannelProto has a linter that checks comments the same English rules.
 formats:
   - "oas3"
 extends: spectral:oas
 functionsDir: isp-functions
 functions:
   - contains
-  - english
+  # - english
   - iso8601
   - noun
 rules:
   # English recommendations for description fields
-  english:
-    severity: warn
-    given: $..description
-    then:
-      function: english
+  # english:
+  #   severity: warn
+  #   given: $..description
+  #   then:
+  #     function: english
   # Use JSON as much as possible
   json-responses:
     severity: error


### PR DESCRIPTION
Our only use case pulls field descriptions from comments in a versioned proto file.  Until that proto file has its own linter that checks for the same English rules, having these rules against only our HTTP API is not tenable.