### PR TITLE
fix: allow special property names like $schema

### DIFF
--- a/fixtures/lint/casing-properties-pass.yaml
+++ b/fixtures/lint/casing-properties-pass.yaml
@@ -30,6 +30,9 @@ paths:
                 items:
                   type: object
                   properties:
+                    $schema:
+                      type: string
+                      description: optional schema describing resource
                     foo_bar:
                       type: string
                       description: foo_bar property

--- a/isp-rules.yaml
+++ b/isp-rules.yaml
@@ -88,7 +88,7 @@ rules:
   # Resource field casing
   properties-lower-snake-case:
     severity: error
-    given: $..properties.*~
+    given: $..properties[?(!@property.toString().startsWith("$"))]
     then:
       function: casing
       functionOptions:


### PR DESCRIPTION
This currently fails when the response contains keys like `$schema`, which can be used by tooling to do things like validation/completion/suggestions-as-you-type. This small change allows the field to bypass the strict `snake` casing rule.