### PR TITLE
feat: add 'cust' as top level exception for noun

### DIFF
--- a/fixtures/lint/noun-pass.yaml
+++ b/fixtures/lint/noun-pass.yaml
@@ -41,3 +41,28 @@ paths:
       responses:
         '204':
           description: Response description
+  /cust/{custId}/product/{productId}:
+    get:
+      summary: Test operation
+      description: Test operation description
+      operationId: test-cust
+      tags:
+        - Test
+      parameters:
+        - name: custId
+          in: path
+          required: true
+          description: some parameter
+          schema:
+            type: string
+            pattern: /[a-z]+/
+        - name: productId
+          in: path
+          required: true
+          description: some parameter
+          schema:
+            type: string
+            pattern: /[a-z]+/
+      responses:
+        '204':
+          description: Response description

--- a/isp-functions/noun-deps.js
+++ b/isp-functions/noun-deps.js
@@ -29,7 +29,7 @@ module.exports = targetValue => {
   // Split into path pieces ignoring blank/empty ones and params.
   let pieces = targetValue.split('/').filter(i => !!i);
 
-  if ((pieces.length === 1 && pieces[0] === 'search') || pieces[0] === 'me') {
+  if ((pieces.length === 1 && pieces[0] === 'search') || pieces[0] === 'me' || pieces[0] === 'cust') {
     // Top-level exceptions. Skip.
     return;
   }


### PR DESCRIPTION
Adds a minor specialized rule to ignore routes starting with `cust` when using the `noun` function. 
