### PR TITLE
fix: noun function should always return list

### DIFF
--- a/isp-functions/noun-deps.js
+++ b/isp-functions/noun-deps.js
@@ -72,5 +72,5 @@ module.exports = targetValue => {
     }
   }
 
-  return errors.length ? errors : null;
+  return errors;
 };


### PR DESCRIPTION
The following error gets thrown if the `noun` function found no errors in the openAPI spec because it currently returns `null`. This PR modifies the function to always return the list even if empty.

```
TypeError: Cannot use 'in' operator to search for 'then' in null
    at Object.exports.lintNode (/action/node_modules/@stoplight/spectral/dist/runner/lintNode.js:40:24)
    at callback (/action/node_modules/@stoplight/spectral/dist/runner/runner.js:38:32)
    at JSONPath._handleCallback (/action/node_modules/jsonpath-plus/dist/index-umd.js:626:7)
    at JSONPath._trace (/action/node_modules/jsonpath-plus/dist/index-umd.js:728:12)
    at JSONPath._trace (/action/node_modules/jsonpath-plus/dist/index-umd.js:689:19)
    at /action/node_modules/jsonpath-plus/dist/index-umd.js:693:21
    at /action/node_modules/jsonpath-plus/dist/index-umd.js:909:9
    at Array.forEach (<anonymous>)
    at JSONPath._walk (/action/node_modules/jsonpath-plus/dist/index-umd.js:908:24)
    at JSONPath._trace (/action/node_modules/jsonpath-plus/dist/index-umd.js:692:12)
```