### PR TITLE
feat: add another specialized exception to noun

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ It's also possible to set it to `warn` or `info`.
 
 The `extends` field is automatically added (or appended to) by the linter script to inject the iSP ruleset into your config.
 
+### Local Development
+
+1. Install `node 13.14.0` locally.
+2. Run `npm run build` to compile the `isp-functions`.
+3. Run `node ./entrypoint.js <PATH_TO_OPENAPI_SPEC>` to run the linter.
+
+The `build` command may need to be re-run to pick up changes made to some of the `isp-functions`.
+
+#### Tests
+
+```sh
+# Compile the isp-functions
+npm run build
+
+# Run test
+npm run test
+```
+
 ## License
 
 Copyright © 2020 iStreamPlanet Co., LLC

--- a/fixtures/lint/noun-pass.yaml
+++ b/fixtures/lint/noun-pass.yaml
@@ -66,3 +66,29 @@ paths:
       responses:
         '204':
           description: Response description
+  /foos/{fooId}/bars/{barId}/preview/watch:
+    get:
+      summary: Test operation
+      description: Test operation description
+      operationId: test-preview
+      tags:
+        - Test
+      parameters:
+        - name: fooId
+          in: path
+          required: true
+          description: some parameter
+          schema:
+            type: string
+            pattern: /[a-z]+/
+        - name: barId
+          in: path
+          required: true
+          description: some parameter
+          schema:
+            type: string
+            pattern: /[a-z]+/
+      responses:
+        '204':
+          description: Response description
+  

--- a/isp-functions/noun-deps.js
+++ b/isp-functions/noun-deps.js
@@ -29,7 +29,7 @@ module.exports = targetValue => {
   // Split into path pieces ignoring blank/empty ones and params.
   let pieces = targetValue.split('/').filter(i => !!i);
 
-  if ((pieces.length === 1 && pieces[0] === 'search') || pieces[0] === 'me' || pieces[0] === 'cust') {
+  if ((pieces.length === 1 && pieces[0] === 'search') || pieces[0] === 'me' || pieces[0] === 'cust' || pieces.length >= 6 && pieces[4] === 'preview') {
     // Top-level exceptions. Skip.
     return;
   }

--- a/isp-functions/noun-deps.js
+++ b/isp-functions/noun-deps.js
@@ -29,7 +29,7 @@ module.exports = targetValue => {
   // Split into path pieces ignoring blank/empty ones and params.
   let pieces = targetValue.split('/').filter(i => !!i);
 
-  if ((pieces.length === 1 && pieces[0] === 'search') || pieces[0] === 'me' || pieces[0] === 'cust' || pieces.length >= 6 && pieces[4] === 'preview') {
+  if ((pieces.length === 1 && pieces[0] === 'search') || pieces[0] === 'me' || pieces[0] === 'cust' || pieces.length === 6 && pieces[4] === 'preview') {
     // Top-level exceptions. Skip.
     return;
   }

--- a/isp-functions/noun-deps.js
+++ b/isp-functions/noun-deps.js
@@ -29,7 +29,7 @@ module.exports = targetValue => {
   // Split into path pieces ignoring blank/empty ones and params.
   let pieces = targetValue.split('/').filter(i => !!i);
 
-  if ((pieces.length === 1 && pieces[0] === 'search') || pieces[0] === 'me' || pieces[0] === 'cust' || pieces.length === 6 && pieces[4] === 'preview') {
+  if ((pieces.length === 1 && pieces[0] === 'search') || pieces[0] === 'me' || pieces[0] === 'cust' || (pieces.length === 6 && pieces[4] === 'preview')) {
     // Top-level exceptions. Skip.
     return;
   }


### PR DESCRIPTION
Adds another minor specialized rule to ignore routes with `preview` when using the `noun` function. This also adds info on how to develop locally and run tests. 
