### PR TITLE
fix: exclude 429 from linter

### DIFF
--- a/isp-rules.yaml
+++ b/isp-rules.yaml
@@ -142,7 +142,7 @@ rules:
     severity: error
     # 429 returns from the API Gateway, so we exclude it
     description: Errors must be problem+JSON or text/plain and include a "detail" field
-    given: $..responses.[?(@property.toString().startsWith("4") || @property.toString() === "500") && @property.toString() != "429"]
+    given: $..responses.[?((@property.toString().startsWith("4") || @property.toString() === "500") && @property.toString() != "429")]
     then:
       - field: content
         function: truthy

--- a/isp-rules.yaml
+++ b/isp-rules.yaml
@@ -140,8 +140,9 @@ rules:
   # Errors must include a `detail` field
   error-detail:
     severity: error
-    description: Errors must be problem+JSON and include a "detail" field
-    given: $..responses.[?(@property.toString().startsWith("4") || @property.toString() === "500")]
+    # 429 returns from the API Gateway, so we exclude it
+    description: Errors must be problem+JSON or text/plain and include a "detail" field
+    given: $..responses.[?(@property.toString().startsWith("4") || @property.toString() === "500") && @property.toString() != "429"]
     then:
       - field: content
         function: truthy


### PR DESCRIPTION
This is sort of a hacky fix. Ideally we would update our load balancer to return `application/problem+json`. In the absence of that kind of control over the load balancer, we omit 429's from the rule in the linter.