### PR TITLE
feat(LIVE-19159) Ignore parameter named 'upid_id' for dns-friendly-rule

### DIFF
--- a/isp-rules.yaml
+++ b/isp-rules.yaml
@@ -65,6 +65,8 @@ rules:
   dns-friendly:
     severity: error
     description: Identifier parameter missing DNS-friendly pattern, e.g. ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+    # 'upid_id' is specifically excluded since it is not an internally defined ID. It is the ID part of a UPID
+    # which should allow any string value.
     given: $..parameters[?((@.name || '').match(/^id[ -_A-Z]|[ -_]id$|[a-z0-9]Id$/) && (@.name || '') !== 'upid_id')]
     then:
       # Currently this just checks for existence of any pattern, but it should

--- a/isp-rules.yaml
+++ b/isp-rules.yaml
@@ -65,7 +65,7 @@ rules:
   dns-friendly:
     severity: error
     description: Identifier parameter missing DNS-friendly pattern, e.g. ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-    given: $..parameters[?((@.name || '').match(/^id[ -_A-Z]|[ -_]id$|[a-z0-9]Id$/))]
+    given: $..parameters[?((@.name || '').match(/^id[ -_A-Z]|[ -_]id$|[a-z0-9]Id$/) && (@.name || '') !== 'upid_id')]
     then:
       # Currently this just checks for existence of any pattern, but it should
       # both catch small mistakes and not be too limited if params have


### PR DESCRIPTION
The dns-friendly-rule should not apply since UPID ID's are not internal IDs and are formatted differently.